### PR TITLE
benchlog: show GIT revision info rather than Mercurial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ endif
 
 benchlog: obj/test/regexp_benchmark
 	(echo '==BENCHMARK==' `hostname` `date`; \
-	  (uname -a; $(CXX) --version; hg identify; file obj/test/regexp_benchmark) | sed 's/^/# /'; \
+	  (uname -a; $(CXX) --version; git rev-parse --short HEAD; file obj/test/regexp_benchmark) | sed 's/^/# /'; \
 	  echo; \
 	  ./obj/test/regexp_benchmark 'PCRE|RE2') | tee -a benchlog.$$(hostname | sed 's/\..*//')
 


### PR DESCRIPTION
Since the project is migrated to GitHub, there is no reason to keep hg commands.