### PR TITLE
Define WIN32_LEAN_AND_MEAN only if it has not been defined already

### DIFF
--- a/util/mutex.h
+++ b/util/mutex.h
@@ -55,7 +55,9 @@ namespace re2 {
 # include <pthread.h>
   typedef pthread_mutex_t MutexType;
 #elif defined(_WIN32)
-# define WIN32_LEAN_AND_MEAN  // We only need minimal includes
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN  // We only need minimal includes
+# endif
 # ifdef GMUTEX_TRYLOCK
   // We need Windows NT or later for TryEnterCriticalSection().  If you
   // don't need that functionality, you can remove these _WIN32_WINNT


### PR DESCRIPTION
In Chrome (and maybe other projects) WIN32_LEAN_AND_MEAN is defined globally by the project environment already. This change makes the behavior a little bit more conservative and should not have any impact on existing projects using RE2. For Chrome it helps reducing the upstream delta.