### PR TITLE
Fix initialization (under Valgrind) in SparseArray::resize().

### DIFF
--- a/util/sparse_array.h
+++ b/util/sparse_array.h
@@ -279,12 +279,12 @@ void SparseArray<Value>::resize(int new_max_size) {
     int* a = new int[new_max_size];
     if (sparse_to_dense_) {
       memmove(a, sparse_to_dense_, max_size_*sizeof a[0]);
-      // Don't need to zero the memory but appease Valgrind.
-      if (InitMemory()) {
-        for (int i = max_size_; i < new_max_size; i++)
-          a[i] = 0xababababU;
-      }
       delete[] sparse_to_dense_;
+    }
+    // Don't need to zero the memory but appease Valgrind.
+    if (InitMemory()) {
+      for (int i = max_size_; i < new_max_size; i++)
+        a[i] = 0xababababU;
     }
     sparse_to_dense_ = a;
 


### PR DESCRIPTION
If SparseArray::resize() is called when sparse_to_dense_ is NULL (which
happens if it was initialized with the default constructor, then
resized) the Valgrind-only initialization code is not run and Valgrind
will complain about uninitialized memory accesses within the newly
allocated array.

This patch moves the init code out of the if (sparse_to_dense_) block
which is safe because in this NULL case max_size_ will be 0 and this
will be equivalent to the init code in the non-default constructor.