### PR TITLE
Set the size of exhaustive_testX to larget

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -113,10 +113,10 @@ re2_test("simplify_test")
 re2_test("string_generator_test")
 
 re2_test("dfa_test")
-re2_test("exhaustive1_test")
-re2_test("exhaustive2_test")
-re2_test("exhaustive3_test")
-re2_test("exhaustive_test")
+re2_test("exhaustive1_test", size="large")
+re2_test("exhaustive2_test", size="large")
+re2_test("exhaustive3_test", size="large")
+re2_test("exhaustive_test", size="large")
 re2_test("random_test", size="large")
 
 # TODO: Add support for regexp_benchmark.


### PR DESCRIPTION
These tests are timing out on ci.bazel.io when validating bazel release, see http://ci.bazel.io/job/re2/BAZEL_VERSION=latest,PLATFORM_NAME=linux-x86_64/71/console