### PR TITLE
Substitute includedir and libdir in re2.pc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,10 @@ install: obj/libre2.a obj/so/libre2.$(SOEXT)
 	$(INSTALL) obj/so/libre2.$(SOEXT) $(DESTDIR)$(libdir)/libre2.$(SOEXTVER00)
 	ln -sf libre2.$(SOEXTVER00) $(DESTDIR)$(libdir)/libre2.$(SOEXTVER)
 	ln -sf libre2.$(SOEXTVER00) $(DESTDIR)$(libdir)/libre2.$(SOEXT)
-	sed -e "s#@prefix@#${prefix}#" re2.pc >$(DESTDIR)$(libdir)/pkgconfig/re2.pc
+	sed -e "s#@prefix@#$(prefix)#" \
+		-e "s#@includedir@#$(includedir)#" \
+		-e "s#@libdir@#$(libdir)#" \
+		re2.pc.in >$(DESTDIR)$(libdir)/pkgconfig/re2.pc
 
 testinstall: static-testinstall shared-testinstall
 	@echo

--- a/re2.pc.in
+++ b/re2.pc.in
@@ -1,7 +1,6 @@
 prefix=@prefix@
-exec_prefix=${prefix}
-includedir=${prefix}/include
-libdir=${exec_prefix}/lib
+includedir=@includedir@
+libdir=@libdir@
 
 Name: re2
 Description: RE2 is a fast, safe, thread-friendly regular expression engine.


### PR DESCRIPTION
Without this, any changes to the Makefile vars are ignored.