### PR TITLE
Pass environment to subshell for dynamic tests

### DIFF
--- a/runtests
+++ b/runtests
@@ -1,10 +1,13 @@
 #!/usr/bin/env sh
 
+LD_LIBRARY_PATH=obj/so:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH
+
 success=true
 for i
 do
 	printf "%-40s" $i
-	if sh -c "$i >$i.log 2>&1" 2>/dev/null
+	if $($i >$i.log 2>&1) 2>/dev/null
 	then
 		echo PASS
 	else


### PR DESCRIPTION
The environment was not getting passed down when running tests, this caused dynamic tests to fail to link correctly on OS X.

See [this thread](https://groups.google.com/forum/#!topic/re2-dev/in4aQvmoxEU) for further discussion.