### PR TITLE
Avoid two warnings from the VS compiler.

### DIFF
--- a/re2/prog.h
+++ b/re2/prog.h
@@ -20,6 +20,11 @@
 #include "util/sparse_set.h"
 #include "re2/re2.h"
 
+#ifdef _WIN32
+#pragma warning (disable : 4201)
+#pragma warning (disable : 4815)
+#endif
+
 namespace re2 {
 
 // Opcodes for Inst

--- a/re2/regexp.h
+++ b/re2/regexp.h
@@ -96,6 +96,11 @@
 #include "util/utf.h"
 #include "re2/stringpiece.h"
 
+#ifdef _WIN32
+#pragma warning (disable : 4201)
+#pragma warning (disable : 4815)
+#endif
+
 namespace re2 {
 
 // Keep in sync with string list kOpcodeNames[] in testing/dump.cc


### PR DESCRIPTION
* Warning C4201: nameless struct/union.
* Warning C4815: zero-sized array in stack object will have no elements.