### PR TITLE
Avoid CMake warning when using re2 as a subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@
 # Old enough to support Ubuntu Trusty.
 cmake_minimum_required(VERSION 2.8.12)
 
+if (POLICY CMP0048)
+  cmake_policy(SET CMP0048 NEW)
+endif (POLICY CMP0048)
+
 project(RE2 CXX)
 include(CTest)
 


### PR DESCRIPTION
Google Test fixed this issue fairly recently too. If you use re2 as a submodule (with CMake add_subdirectory) then you might see warnings like this. This patch should avoid them for all versions of CMake. It shouldn't change behaviour as you do not seem to be using the VERSION variables it is talking about.

```
CMake Warning (dev) at external/re2/re2/CMakeLists.txt:8 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    PROJECT_VERSION
    PROJECT_VERSION_MAJOR
    PROJECT_VERSION_MINOR
    PROJECT_VERSION_PATCH
This warning is for project developers.  Use -Wno-dev to suppress it.
```
