### PR TITLE
Build with clang 5.0 by adding -std=c++11

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -63,7 +63,7 @@ cc_library(
     copts = [
         # Suppress known warnings.
         "-Wno-c99-extensions",
-
+        "-std=c++11",
         "-pthread",
     ],
     linkopts = ["-pthread"],
@@ -91,6 +91,9 @@ cc_library(
         "util/benchmark.h",
         "util/pcre.h",
         "util/test.h",
+    ],
+    copts = [
+        "-std=c++11",
     ],
     deps = [":re2"],
 )
@@ -208,6 +211,9 @@ cc_library(
     name = "benchmark",
     testonly = 1,
     srcs = ["util/benchmark.cc"],
+    copts = [
+        "-std=c++11",
+    ],
     deps = [":testing"],
 )
 
@@ -215,6 +221,9 @@ cc_binary(
     name = "regexp_benchmark",
     testonly = 1,
     srcs = ["re2/testing/regexp_benchmark.cc"],
+    copts = [
+        "-std=c++11",
+    ],
     linkopts = [
         "-lm",
         "-lrt",

--- a/BUILD
+++ b/BUILD
@@ -57,7 +57,15 @@ cc_library(
         "re2/set.h",
         "re2/stringpiece.h",
     ],
-    copts = ["-pthread"],
+    includes = [
+        ".",
+    ],
+    copts = [
+        # Suppress known warnings.
+        "-Wno-c99-extensions",
+
+        "-pthread",
+    ],
     linkopts = ["-pthread"],
     visibility = ["//visibility:public"],
 )

--- a/re2_test.bzl
+++ b/re2_test.bzl
@@ -7,6 +7,9 @@ def re2_test(name, deps=[], size="medium"):
   native.cc_test(
       name=name,
       srcs=["re2/testing/%s.cc" % (name)],
+      copts = [
+        "-std=c++11",
+      ],
       deps=[":test"] + deps,
       size = size,
   )


### PR DESCRIPTION
The Bazel BUILD file lacks a few `-std=c++11` flags.

On a Ubuntu 16.04 x86_64 machine with clang5.0.0, the default dialect of C++ is pretty old. We should mandate it to at least c++11.

Some errors I got without using these `-std=c++11` flags are:
```
re2/re2.h:915:5: error: no matching function for call to 'call_once'
    std::call_once(once_, &LazyRE2::Init, this);
```

All tests pass as I tested.