### PR TITLE
fix build fail on locale windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   # CMake defaults to /W3, but some users like /W4 (or /Wall) and /WX,
   # so we disable various warnings that aren't particularly helpful.
   add_compile_options(/wd4100 /wd4201 /wd4456 /wd4457 /wd4702 /wd4815)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /source-charset:utf-8")
 elseif(CYGWIN OR MINGW)
   # See https://stackoverflow.com/questions/38139631 for details.
   add_compile_options(-std=gnu++11)


### PR DESCRIPTION
Because msvc use locale code page to open source code file by default, it cause build break on non-english Windows.

Error msg:

    1>------ 已開始建置: 專案: re2_test, 組態: Release x64 ------
    1>re2_test.cc
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(905): warning C4819: 檔案含有無法在目前字碼頁 (950) 中表示的字元。請以 Unicode 格式儲存檔案以防止資料遺失
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1281): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1282): error C2064: 詞彙不等於使用 1 引數的函式
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1284): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1285): error C2064: 詞彙不等於使用 1 引數的函式
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1287): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1288): error C2064: 詞彙不等於使用 1 引數的函式
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1296): error C2059: 語法錯誤: ';'
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1298): error C2070: 're2::ErrorTest []': sizeof 運算元不合法，必須是運算式或類型名稱
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1365): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1366): error C2146: 語法錯誤: 遺漏 ';' (在識別項 'string' 之前)
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1375): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1376): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1377): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1378): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1379): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1380): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1382): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1383): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1384): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1385): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1386): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1387): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1389): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1390): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1391): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1392): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1393): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1394): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1416): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1417): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1418): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1630): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1631): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\re2_test.cc(1375): fatal error C1057: 巨集展開中未預期的檔案結尾
    1>專案 "re2_test.vcxproj" 建置完成 -- 失敗。
    ========== 建置: 0 成功、1 失敗、3 最新、0 略過 ==========
    
    1>------ 已開始建置: 專案: search_test, 組態: Release x64 ------
    1>search_test.cc
    1>C:\Users\User\Source\Repos\re2\re2\testing\search_test.cc : warning C4819: 檔案含有無法在目前字碼頁 (950) 中表示的字元。請以 Unicode 格式儲存檔案以防止資料遺失
    1>C:\Users\User\Source\Repos\re2\re2\testing\search_test.cc(244): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\search_test.cc(245): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\search_test.cc(246): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\search_test.cc(247): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\search_test.cc(248): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\search_test.cc(249): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\search_test.cc(250): error C2001: 常數中包含新行字元
    1>C:\Users\User\Source\Repos\re2\re2\testing\search_test.cc(252): error C2064: 詞彙不等於使用 1 引數的函式
    1>C:\Users\User\Source\Repos\re2\re2\testing\search_test.cc(311): error C2064: 詞彙不等於使用 1 引數的函式
    1>C:\Users\User\Source\Repos\re2\re2\testing\search_test.cc(311): error C2059: 語法錯誤: ';'
    1>C:\Users\User\Source\Repos\re2\re2\testing\search_test.cc(315): error C2070: 're2::RegexpTest []': sizeof 運算元不合法，必須是運算式或類型名稱
    1>專案 "search_test.vcxproj" 建置完成 -- 失敗。
    ========== 建置: 0 成功、1 失敗、3 最新、0 略過 ==========
