### PR TITLE
Mention Varnish VMOD re2 in README.

### DIFF
--- a/README
+++ b/README
@@ -36,3 +36,4 @@ A Perl wrapper is at https://github.com/dgl/re-engine-RE2/ and on CPAN (cpan.org
 A Python wrapper is at https://github.com/facebook/pyre2/ and on PyPI (pypi.org).
 An R wrapper is at https://github.com/qinwf/re2r/ and on CRAN (cran.r-project.org).
 A Ruby wrapper is at https://github.com/mudge/re2/ and on RubyGems (rubygems.org).
+A Varnish VMOD is at https://code.uplex.de/uplex-varnish/libvmod-re2/.


### PR DESCRIPTION
The VMOD wraps RE2 and makes it accessible in VCL (Varnish Configuration Language).