### PR TITLE
Added option to report back what was matched in RE2::Set

### DIFF
--- a/re2/set.cc
+++ b/re2/set.cc
@@ -102,12 +102,12 @@ bool RE2::Set::Compile() {
   return prog_ != NULL;
 }
 
-bool RE2::Set::Match(const StringPiece& text, std::vector<int>* v) const {
-  return Match(text, v, NULL);
+bool RE2::Set::Match(const StringPiece& text, std::vector<int>* v, StringPiece* match0) const {
+  return Match(text, v, NULL, match0);
 }
 
 bool RE2::Set::Match(const StringPiece& text, std::vector<int>* v,
-                     ErrorInfo* error_info) const {
+                     ErrorInfo* error_info, StringPiece* match0) const {
   if (!compiled_) {
     LOG(DFATAL) << "RE2::Set::Match() called before compiling";
     if (error_info != NULL)
@@ -121,7 +121,7 @@ bool RE2::Set::Match(const StringPiece& text, std::vector<int>* v,
     v->clear();
   }
   bool ret = prog_->SearchDFA(text, text, Prog::kAnchored, Prog::kManyMatch,
-                              NULL, &dfa_failed, matches.get());
+                              match0, &dfa_failed, matches.get());
   if (dfa_failed) {
     if (options_.log_errors())
       LOG(ERROR) << "DFA out of memory: size " << prog_->size() << ", "

--- a/re2/set.h
+++ b/re2/set.h
@@ -53,13 +53,17 @@ class RE2::Set {
   // Returns true if text matches at least one of the regexps in the set.
   // Fills v (if not NULL) with the indices of the matching regexps.
   // Callers must not expect v to be sorted.
-  bool Match(const StringPiece& text, std::vector<int>* v) const;
+  // If a match is found, fills in match0->end() to point at the end of the match
+  // and sets match0->begin() to text.begin(). This won't work unless you specify v
+  // because otherwise Set reports the earliest match possible and it can be shorter
+  // then what would actually be read out from the text.
+  bool Match(const StringPiece& text, std::vector<int>* v, StringPiece* match0 = NULL) const;
 
   // As above, but populates error_info (if not NULL) when none of the regexps
   // in the set matched. This can inform callers when DFA execution fails, for
   // example, because they might wish to handle that case differently.
   bool Match(const StringPiece& text, std::vector<int>* v,
-             ErrorInfo* error_info) const;
+             ErrorInfo* error_info, StringPiece* match0 = NULL) const;
 
  private:
   typedef std::pair<std::string, re2::Regexp*> Elem;

--- a/re2/testing/set_test.cc
+++ b/re2/testing/set_test.cc
@@ -201,4 +201,25 @@ TEST(Set, Prefix) {
   ASSERT_EQ(v[0], 0);
 }
 
+TEST(Set, MatchLength) {
+	RE2::Set s(RE2::DefaultOptions, RE2::ANCHOR_START);
+
+	ASSERT_EQ(s.Add("[a-z]+", NULL), 0);
+	ASSERT_EQ(s.Compile(), true);
+
+	std::vector<int> v;
+	std::vector<StringPiece> match(3);
+	ASSERT_EQ(s.Match("   ", &v, &match[0]), false);
+	ASSERT_EQ(s.Match("abc", &v, &match[1]), true);
+	ASSERT_EQ(s.Match("abcdef  ", &v, &match[2]), true);
+
+	ASSERT_EQ(match[0].size(), 0);
+
+	ASSERT_EQ(match[1].size(), 3);
+	ASSERT_EQ(match[1].as_string(), "abc");
+
+	ASSERT_EQ(match[2].size(), 6);
+	ASSERT_EQ(match[2].as_string(), "abcdef");
+}
+
 }  // namespace re2


### PR DESCRIPTION
I would really like to use `RE2::Set` in my project but I need it to report back the length of what was matched so I can call `remove_prefix()` on the input and continue matching on the rest of the input.

Drawback is that you must also specify vector for reporting matched regexpses otherwise earliest possible match is reported and it does not match the length of what would be actually read. Other than that, it works like expected for my use-case.