### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README
+++ b/README
@@ -10,6 +10,10 @@ make test
 make install
 make testinstall
 
+If you are using the vcpkg dependency manager (https://github.com/Microsoft/vcpkg/) you can download and install RE2 with CMake integration in a single command:
+
+vcpkg install re2
+
 There is a fair amount of documentation (including code snippets) in
 the re2.h header file.
 


### PR DESCRIPTION
RE2 is available as a port in vcpkg. Adding installation instructions will help users get started by providing a single command they can use to build RE2 and include it into their CMake projects