### PR TITLE
Use delete[] to delete child_args array

### DIFF
--- a/re2/walker-inl.h
+++ b/re2/walker-inl.h
@@ -150,7 +150,7 @@ template<typename T> void Regexp::Walker<T>::Reset() {
   if (stack_ && stack_->size() > 0) {
     LOG(DFATAL) << "Stack not empty.";
     while (stack_->size() > 0) {
-      delete stack_->top().child_args;
+      delete[] stack_->top().child_args;
       stack_->pop();
     }
   }


### PR DESCRIPTION
This is probably benign because it happens in a function that should never be called.