### PR TITLE
Fix `Replace` and friends to match RE

### DIFF
--- a/re2/re2.cc
+++ b/re2/re2.cc
@@ -368,9 +368,10 @@ bool RE2::Replace(std::string* str,
                   const RE2& re,
                   const StringPiece& rewrite) {
   StringPiece vec[kVecSize];
-  int nvec = 1 + MaxSubmatch(rewrite);
+  int nvec = 1 + re.NumberOfCapturingGroups();
   if (nvec > static_cast<int>(arraysize(vec)))
     return false;
+
   if (!re.Match(*str, 0, str->size(), UNANCHORED, vec, nvec))
     return false;
 
@@ -388,7 +389,7 @@ int RE2::GlobalReplace(std::string* str,
                        const RE2& re,
                        const StringPiece& rewrite) {
   StringPiece vec[kVecSize];
-  int nvec = 1 + MaxSubmatch(rewrite);
+  int nvec = 1 + re.NumberOfCapturingGroups();
   if (nvec > static_cast<int>(arraysize(vec)))
     return false;
 
@@ -460,7 +461,7 @@ bool RE2::Extract(const StringPiece& text,
                   const StringPiece& rewrite,
                   std::string* out) {
   StringPiece vec[kVecSize];
-  int nvec = 1 + MaxSubmatch(rewrite);
+  int nvec = 1 + re.NumberOfCapturingGroups();
   if (nvec > static_cast<int>(arraysize(vec)))
     return false;
 

--- a/re2/testing/re2_test.cc
+++ b/re2/testing/re2_test.cc
@@ -223,6 +223,14 @@ TEST(RE2, Extract) {
   ASSERT_EQ(s, "'foo'");
 }
 
+TEST(RE2, RewriteErrorHandling) {
+  std::string s;
+
+  ASSERT_FALSE(RE2::Extract("foo", "f(o+)", "\\2", &s));
+  ASSERT_FALSE(RE2::Replace(&s, "f(o+)", "\\2\\2"));
+  ASSERT_FALSE(RE2::GlobalReplace(&s, "f(o+)", "\\2\\2"));
+}
+
 TEST(RE2, Consume) {
   RE2 r("\\s*(\\w+)");    // matches a word, possibly proceeded by whitespace
   std::string word;


### PR DESCRIPTION
RE1 uses the pattern to determine the number of valid captures not the
rewrite.

TESTED=unit