### PR TITLE
Fix syntax for gcc 11

### DIFF
--- a/re2/walker-inl.h
+++ b/re2/walker-inl.h
@@ -119,7 +119,7 @@ template<typename T> T Regexp::Walker<T>::Copy(T arg) {
 
 // State about a single level in the traversal.
 template<typename T> struct WalkState {
-  WalkState<T>(Regexp* re, T parent)
+  WalkState(Regexp* re, T parent)
     : re(re),
       n(-1),
       parent_arg(parent),


### PR DESCRIPTION
Hello,

GCC 11 does not accept this syntax when the chosen standard is C++20.

```
In file included from re2/mimics_pcre.cc:28:
./re2/walker-inl.h:122:22: error: expected ')' before '*' token
  122 |   WalkState<T>(Regexp* re, T parent)
      |               ~      ^
      |                      )
```

In any case, I don't think this `<T>` is really useful.