### PR TITLE
Comment out unused lambda parameter names

### DIFF
--- a/re2/re2.h
+++ b/re2/re2.h
@@ -819,7 +819,8 @@ class RE2::Arg {
  public:
   Arg() : Arg(nullptr) {}
   Arg(std::nullptr_t ptr)
-      : arg_(ptr), parser_([](const char* str, size_t n, void* dest) -> bool {
+      : arg_(ptr),
+        parser_([](const char* /*str*/, size_t /*n*/, void* /*dest*/) -> bool {
           return true;
         }) {}
 


### PR DESCRIPTION
Avoid triggering a warning in client libraries when they use higher
warning levels.