### PR TITLE
remove -std=c++11 from pkg-config Cflags

### DIFF
--- a/.github/workflows/ci-bazel.yml
+++ b/.github/workflows/ci-bazel.yml
@@ -1,7 +1,6 @@
 name: CI (Bazel)
 on:
   push:
-    branches: [master]
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-cmake.yml
+++ b/.github/workflows/ci-cmake.yml
@@ -1,7 +1,6 @@
 name: CI (CMake)
 on:
   push:
-    branches: [master]
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 on:
   push:
-    branches: [master]
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/re2.pc
+++ b/re2.pc
@@ -4,5 +4,5 @@ libdir=@libdir@
 Name: re2
 Description: RE2 is a fast, safe, thread-friendly regular expression engine.
 Version: 0.0.0
-Cflags: -std=c++11 -pthread -I${includedir}
+Cflags: -pthread -I${includedir}
 Libs: -pthread -L${libdir} -lre2


### PR DESCRIPTION
The option does not belong there, as pkg-config Cflags tend to make it
into the CFLAGS of projects that rely on re2. This means that such a
project finds itself accidentally using -std=c++11 when it did not
intend to do so.

===

additionally, I wonder if `-pthread` does belong in there, but I did not spend time on that because it did not break the https://github.com/PowerDNS/pdns build.