### PR TITLE
Add reference to re2-wasm in README

### DIFF
--- a/README
+++ b/README
@@ -34,6 +34,7 @@ A C wrapper is at https://github.com/marcomaggi/cre2/.
 An Erlang wrapper is at https://github.com/dukesoferl/re2/ and on Hex (hex.pm).
 An Inferno wrapper is at https://github.com/powerman/inferno-re2/.
 A Node.js wrapper is at https://github.com/uhop/node-re2/ and on NPM (npmjs.com).
+Another Node.js wrapper is at https://github.com/google/re2-wasm and on NPM (npmjs.com).
 An OCaml wrapper is at https://github.com/janestreet/re2/ and on OPAM (opam.ocaml.org).
 A Perl wrapper is at https://github.com/dgl/re-engine-RE2/ and on CPAN (cpan.org).
 An R wrapper is at https://github.com/qinwf/re2r/ and on CRAN (cran.r-project.org).


### PR DESCRIPTION
I published re2-wasm today and it would be useful to have a link to it in the README.