### PR TITLE
Drop macro-based protection from anonymous MutexLock usage

### DIFF
--- a/util/mutex.h
+++ b/util/mutex.h
@@ -138,11 +138,6 @@ class WriterMutexLock {
   WriterMutexLock& operator=(const WriterMutexLock&) = delete;
 };
 
-// Catch bug where variable name is omitted, e.g. MutexLock (&mu);
-#define MutexLock(x) static_assert(false, "MutexLock declaration missing variable name")
-#define ReaderMutexLock(x) static_assert(false, "ReaderMutexLock declaration missing variable name")
-#define WriterMutexLock(x) static_assert(false, "WriterMutexLock declaration missing variable name")
-
 }  // namespace re2
 
 #endif  // UTIL_MUTEX_H_


### PR DESCRIPTION
This macro-based protection appeared at least 5 years ago.

At the time the case it protects from just does not compile (I wonder if it ever did). I have compiled the following test code:

```
#include <util/mutex.h>

int main() {
    re2::Mutex mu;
    re2::MutexLock (&mu);
    return 0;
}
```

and got the following errors from clang:
```
.../main.cpp:5:22: error: redefinition of 'mu' with a different type: 're2::MutexLock (&)' vs 're2::Mutex'
    re2::MutexLock (&mu);
                     ^
.../main.cpp:4:16: note: previous definition is here
    re2::Mutex mu;
               ^
.../main.cpp:5:22: error: declaration of reference variable 'mu' requires an initializer
    re2::MutexLock (&mu);
                     ^~
2 errors generated.
Failed
```

gcc:
```
.../main.cpp: In function 'int main()':
.../main.cpp:5:24: error: conflicting declaration 're2::MutexLock& mu'
     re2::MutexLock (&mu);
                        ^
.../main.cpp:4:16: note: previous declaration as 're2::Mutex mu'
     re2::Mutex mu;
                ^~
Failed
```

msvc:
```
.../main.cpp:5: error C2040: 'mu': 're2::MutexLock &' differs in levels of indirection from 're2::Mutex'
.../main.cpp:5: error C2530: 'mu': references must be initialized
Failed
```

At the time these macros cause trouble when cross-used with google protobuf, which [has](https://github.com/protocolbuffers/protobuf/blob/630028a4c6442cfcfabf9c770870a441b3096da8/src/google/protobuf/stubs/mutex.h#L139) `MutexLock` (at least opensource version of protobuf does).