### PR TITLE
Instructions on how to build RE2 for Windows

### DIFF
--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -1,0 +1,10 @@
+# How to build re2 on Windows platforms
+
+You can build RE2 for Windows with Microsoft Visual Studio by the Bazel build tool <https://bazel.build/>
+
+1. Download Bazel Windows binary at <https://github.com/bazelbuild/bazel/releases> (scroll down and look for an .exe file)
+2. Put the Bazel binary in the root directory of RE2, or add a directory with the Bazel binary to %PATH%.
+3. Run the Visual Studio command prompt from the Start Menu, e.g., the the "x64 Native Tools Command Prompt"
+4. In the command prompt, go to your RE2 root directory, e.g. `cd c:\gitrepos\re2`
+5. Run `bazel.exe build :all`
+6. Bazel will create the following subdirectoris in you RE2 root directory: `bazel-bin`, `bazel-out`, `bazel-re2`, `bazel-testlogs`. You will find the compiled RE2 binaries, i.e. the library and the test programs (.lib, .pdb, .exe) at `bazel-bin`. For example, you may run `regexp_benchmark.exe` from `bazel-bin`


### PR DESCRIPTION
There were no instructions on how to build RE2 for Windows.

While on Linux it is quite straightforward to build, and you have provided the instructions in the README file, it was not that obvious for a general user on how to build RE2 for Windows using native Windows tools like Microsoft Visual Studio.

I propose the small instruction. The file is named in a similar fashion as notes on how to build OpenSSL on various platforms, e.g. https://github.com/openssl/openssl/