### PR TITLE
Fixed crash when deleting pointer to stack variable

### DIFF
--- a/re2/walker-inl.h
+++ b/re2/walker-inl.h
@@ -185,9 +185,7 @@ template<typename T> T Regexp::Walker<T>::WalkInternal(Regexp* re, T top_arg,
         }
         s->n = 0;
         s->child_args = NULL;
-        if (re->nsub_ == 1)
-          s->child_args = &s->child_arg;
-        else if (re->nsub_ > 1)
+        if (re->nsub_ > 1)
           s->child_args = new T[re->nsub_];
         FALLTHROUGH_INTENDED;
       }
@@ -205,7 +203,8 @@ template<typename T> T Regexp::Walker<T>::WalkInternal(Regexp* re, T top_arg,
           }
         }
 
-        t = PostVisit(re, s->parent_arg, s->pre_arg, s->child_args, s->n);
+        T* child_args = (re->nsub_ == 1) ? &s->child_arg : s->child_args;
+        t = PostVisit(re, s->parent_arg, s->pre_arg, child_args, s->n);
         if (re->nsub_ > 1)
           delete[] s->child_args;
         break;


### PR DESCRIPTION
The PR fixes crash happening when trying to delete a pointer to a variable located on stack.
The following crash stack trace should describe the situation better:

```
104 : <stripped>!re2::Regexp::Walker<re2::Regexp *>::Reset+0xcf [C:\Libs\RE2\re2\walker-inl.h @ 151 ]
103 : <stripped>!re2::CoalesceWalker::~CoalesceWalker+0x18
102 : <stripped>\VCRUNTIME140_1.dll!CallSettingFrameEncoded+0x2a
101 : <stripped>\VCRUNTIME140_1.dll!__FrameHandler4::FrameUnwindToState+0x269
100 : <stripped>\VCRUNTIME140_1.dll!__FrameHandler4::FrameUnwindToEmptyState+0x2d
99 : <stripped>\VCRUNTIME140_1.dll!__InternalCxxFrameHandler<__FrameHandler4>+0x19b
98 : <stripped>\VCRUNTIME140_1.dll!_CxxFrameHandler4+0xa9
97 : <stripped>!__GSHandlerCheck_EH4+0x64 [d:\agent\_work\63\s\src\vctools\crt\vcstartup\src\gs\amd64\gshandlereh4.cpp @ 86 ]
96 : C:\Windows\SYSTEM32\ntdll.dll!RtlpExecuteHandlerForUnwind+0xf
95 : C:\Windows\SYSTEM32\ntdll.dll!RtlUnwindEx+0x51c
94 : <stripped>\VCRUNTIME140_1.dll!__FrameHandler4::UnwindNestedFrames+0x128
93 : <stripped>\VCRUNTIME140_1.dll!CatchIt<__FrameHandler4>+0xb9
92 : <stripped>\VCRUNTIME140_1.dll!FindHandler<__FrameHandler4>+0x396
91 : <stripped>\VCRUNTIME140_1.dll!__InternalCxxFrameHandler<__FrameHandler4>+0x273
90 : <stripped>\VCRUNTIME140_1.dll!_CxxFrameHandler4+0xa9
89 : C:\Windows\SYSTEM32\ntdll.dll!RtlpExecuteHandlerForException+0xf
88 : C:\Windows\SYSTEM32\ntdll.dll!RtlDispatchException+0x40f
87 : C:\Windows\SYSTEM32\ntdll.dll!RtlRaiseException+0x316
86 : C:\Windows\System32\KERNELBASE.dll!RaiseException+0x69
85 : <stripped>\VCRUNTIME140.dll!_CxxThrowException+0xc2 [f:\dd\vctools\crt\vcruntime\src\eh\throw.cpp @ 136 ]
84 : <stripped>!re2::SimplifyWalker::Concat2+0xc0 [C:\Libs\RE2\re2\simplify.cc @ 575 ]
83 : <stripped>!re2::SimplifyWalker::SimplifyRepeat+0x2a6 [C:\Libs\RE2\re2\simplify.cc @ 634 ]
82 : <stripped>!re2::SimplifyWalker::PostVisit+0x27a [C:\Libs\RE2\re2\simplify.cc @ 553 ]
81 : <stripped>!re2::Regexp::Walker<re2::Regexp *>::WalkInternal+0x262 [C:\Libs\RE2\re2\walker-inl.h @ 208 ]
80 : <stripped>!re2::Regexp::Simplify+0x2e3 [C:\Libs\RE2\re2\simplify.cc @ 187 ]
79 : <stripped>!re2::Compiler::Compile+0xb9 [C:\Libs\RE2\re2\compile.cc @ 1118 ]
78 : <stripped>!re2::RE2::Init+0x5ab [C:\Libs\RE2\re2\re2.cc @ 222 ]
77 : <stripped>!re2::RE2::RE2+0xa7 [C:\Libs\RE2\re2\re2.cc @ 
```

The crash happens when an exception occurs during traversal.