### PR TITLE
Makefile: fix 'make testinstall -j' race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,8 +337,8 @@ ifeq ($(shell uname),Darwin)
 else ifeq ($(shell uname),SunOS)
 	@echo Skipping test for libre2.a on SunOS.
 else
-	(cd obj && $(CXX) testinstall.cc -o testinstall $(CXXFLAGS) $(LDFLAGS))
-	obj/testinstall
+	(cd obj && $(CXX) testinstall.cc -o static-testinstall $(CXXFLAGS) $(LDFLAGS))
+	obj/static-testinstall
 endif
 
 .PHONY: shared-testinstall
@@ -347,11 +347,11 @@ shared-testinstall: LDFLAGS:=-pthread -L$(DESTDIR)$(libdir) -lre2 $(LDICU) $(LDF
 shared-testinstall:
 	@mkdir -p obj
 	@cp testinstall.cc obj
-	(cd obj && $(CXX) testinstall.cc -o testinstall $(CXXFLAGS) $(LDFLAGS))
+	(cd obj && $(CXX) testinstall.cc -o shared-testinstall $(CXXFLAGS) $(LDFLAGS))
 ifeq ($(shell uname),Darwin)
-	DYLD_LIBRARY_PATH="$(DESTDIR)$(libdir):$(DYLD_LIBRARY_PATH)" obj/testinstall
+	DYLD_LIBRARY_PATH="$(DESTDIR)$(libdir):$(DYLD_LIBRARY_PATH)" obj/shared-testinstall
 else
-	LD_LIBRARY_PATH="$(DESTDIR)$(libdir):$(LD_LIBRARY_PATH)" obj/testinstall
+	LD_LIBRARY_PATH="$(DESTDIR)$(libdir):$(LD_LIBRARY_PATH)" obj/shared-testinstall
 endif
 
 .PHONY: benchlog


### PR DESCRIPTION
Noticed buld failure as part of distribution package build:

    $ LANG=C make -j16 testinstall
    (cd obj && g++ testinstall.cc -o testinstall -std=c++11 -pthread -I/usr/local/include -O3 -g -pthread -L/usr/local/lib -l:libre2.a  )
    (cd obj && g++ testinstall.cc -o testinstall -std=c++11 -pthread -I/usr/local/include -O3 -g -pthread -L/usr/local/lib -lre2  )
    LD_LIBRARY_PATH="/usr/local/lib:" obj/testinstall
    sh: line 1: obj/testinstall: Text file busy

Note how shared and static tests share intermediate binary name.
The change uses static- and shared- prefixes for final binary.