### PR TITLE
Check for undefined TARGET_OS_OSX

### DIFF
--- a/re2/re2.h
+++ b/re2/re2.h
@@ -971,7 +971,7 @@ namespace hooks {
 // As per https://github.com/google/re2/issues/325, thread_local support in
 // MinGW seems to be buggy. (FWIW, Abseil folks also avoid it.)
 #define RE2_HAVE_THREAD_LOCAL
-#if (defined(__APPLE__) && !TARGET_OS_OSX) || defined(__MINGW32__)
+#if (defined(__APPLE__) && (!defined(TARGET_OS_OSX) || !TARGET_OS_OSX)) || defined(__MINGW32__)
 #undef RE2_HAVE_THREAD_LOCAL
 #endif
 


### PR DESCRIPTION
This isn't defined by older Mac OS X SDKs, and newer compilers complain about that.