### PR TITLE
Add `std::string_view` support to `StringPiece` and submatch extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 core
 obj/
 benchlog.*
+out/
+.vs/
+.vscode/

--- a/re2/re2.cc
+++ b/re2/re2.cc
@@ -1050,6 +1050,15 @@ bool Parse(const char* str, size_t n, std::string* dest) {
   return true;
 }
 
+#if __has_include(<string_view>) && __cplusplus >= 201703L
+template <>
+bool Parse(const char* str, size_t n, std::string_view* dest) {
+  if (dest == NULL) return true;
+  *dest = std::string_view(str, n);
+  return true;
+}
+#endif
+
 template <>
 bool Parse(const char* str, size_t n, StringPiece* dest) {
   if (dest == NULL) return true;

--- a/re2/re2.h
+++ b/re2/re2.h
@@ -208,6 +208,9 @@
 #include <map>
 #include <mutex>
 #include <string>
+#if __has_include(<string_view>) && __cplusplus >= 201703L
+#include <string_view>
+#endif
 #include <type_traits>
 #include <vector>
 
@@ -789,6 +792,9 @@ namespace re2_internal {
 template <typename T> struct Parse3ary : public std::false_type {};
 template <> struct Parse3ary<void> : public std::true_type {};
 template <> struct Parse3ary<std::string> : public std::true_type {};
+#if __has_include(<string_view>) && __cplusplus >= 201703L
+template <> struct Parse3ary<std::string_view> : public std::true_type {};
+#endif
 template <> struct Parse3ary<StringPiece> : public std::true_type {};
 template <> struct Parse3ary<char> : public std::true_type {};
 template <> struct Parse3ary<signed char> : public std::true_type {};

--- a/re2/stringpiece.h
+++ b/re2/stringpiece.h
@@ -123,6 +123,22 @@ class StringPiece {
     return std::string(data_, size_);
   }
 
+#if __has_include(<string_view>) && __cplusplus >= 201703L
+  // Converts to `std::string_view`.
+  operator std::string_view() const {
+    if (!data_) return {};
+    return std::string_view(data_, size_);
+  }
+
+  std::string_view as_string_view() const {
+    return std::string_view(data_, size_);
+  }
+
+  std::string_view ToStringView() const {
+    return std::string_view(data_, size_);
+  }
+#endif
+
   void CopyToString(std::string* target) const {
     target->assign(data_, size_);
   }

--- a/re2/testing/re2_test.cc
+++ b/re2/testing/re2_test.cc
@@ -11,6 +11,9 @@
 #include <string.h>
 #include <map>
 #include <string>
+#if __has_include(<string_view>) && __cplusplus >= 201703L
+#include <string_view>
+#endif
 #include <utility>
 #include <vector>
 #if !defined(_MSC_VER) && !defined(__CYGWIN__) && !defined(__MINGW32__)
@@ -1655,5 +1658,32 @@ TEST(RE2, Issue310) {
   ASSERT_TRUE(plus.Match(s, 0, s.size(), RE2::UNANCHORED, &m, 1));
   ASSERT_EQ(m, "") << " got m='" << m << "', want ''";
 }
+
+#if __has_include(<string_view>) && __cplusplus >= 201703L
+TEST(RE2, StringView) {
+  RE2 r("(foo)|(bar)|(baz)");
+  std::string_view word1;
+  std::string_view word2;
+  std::string_view word3;
+
+  ASSERT_TRUE(RE2::PartialMatch("foo", r, &word1, &word2, &word3));
+  ASSERT_EQ(word1, "foo");
+  ASSERT_EQ(word2, "");
+  ASSERT_EQ(word3, "");
+  ASSERT_TRUE(RE2::PartialMatch("bar", r, &word1, &word2, &word3));
+  ASSERT_EQ(word1, "");
+  ASSERT_EQ(word2, "bar");
+  ASSERT_EQ(word3, "");
+  ASSERT_TRUE(RE2::PartialMatch("baz", r, &word1, &word2, &word3));
+  ASSERT_EQ(word1, "");
+  ASSERT_EQ(word2, "");
+  ASSERT_EQ(word3, "baz");
+  ASSERT_FALSE(RE2::PartialMatch("f", r, &word1, &word2, &word3));
+
+  std::string_view a;
+  ASSERT_TRUE(RE2::FullMatch("hello", "(foo)|hello", &a));
+  ASSERT_EQ(a, "");
+}
+#endif
 
 }  // namespace re2


### PR DESCRIPTION
Hello, I have found a bit annoying to convert `re2::StringPiece` to `std::string_view` by hands every time so I tried to fix this.