### PR TITLE
Make stringview.h accept absl::string_view

### DIFF
--- a/re2/stringpiece.h
+++ b/re2/stringpiece.h
@@ -52,12 +52,13 @@ class StringPiece {
   // expected.
   StringPiece()
       : data_(NULL), size_(0) {}
-#ifdef __cpp_lib_string_view
-  StringPiece(const std::string_view& str)
+
+  // Construct from anything that looks string-like with data() and size().
+  // Such as std::string, std::string_view or absl::string_view
+  template <typename StringT = std::string>
+  StringPiece(const StringT& str)
       : data_(str.data()), size_(str.size()) {}
-#endif
-  StringPiece(const std::string& str)
-      : data_(str.data()), size_(str.size()) {}
+
   StringPiece(const char* str)
       : data_(str), size_(str == NULL ? 0 : strlen(str)) {}
   StringPiece(const char* str, size_type len)


### PR DESCRIPTION
This fixes trouble when RE2 is used in conjucntion with absl.
If absl::string_view is its own type instead of a typedef
to std::string_view (for anything < C++17), the RE2 string-view
adaption can't deal with it.

Solve this by making the constructor a template that accepts anything
with data(), size() without needing the knowledge if absl::string_view
is even used.

Signed-off-by: Henner Zeller <h.zeller@acm.org>