### PR TITLE
Enable building Apple frameworks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,14 +90,39 @@ set(RE2_SOURCES
     re2/unicode_casefold.cc
     re2/unicode_groups.cc
     util/rune.cc
-    util/strutil.cc
-    )
+    util/strutil.cc)
 
-add_library(re2 ${RE2_SOURCES})
+set(RE2_HEADERS
+    re2/bitmap256.h
+    re2/pod_array.h
+    re2/prefilter_tree.h
+    re2/re2.h
+    re2/set.h
+    re2/sparse_set.h
+    re2/unicode_casefold.h
+    re2/walker-inl.h
+    re2/filtered_re2.h
+    re2/prefilter.h
+    re2/prog.h
+    re2/regexp.h
+    re2/sparse_array.h
+    re2/stringpiece.h
+    re2/unicode_groups.h)
+
+add_library(re2 ${RE2_SOURCES} ${RE2_HEADERS})
 target_compile_features(re2 PUBLIC cxx_std_11)
 target_include_directories(re2 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 set_target_properties(re2 PROPERTIES SOVERSION ${SONAME} VERSION ${SONAME}.0.0)
 add_library(re2::re2 ALIAS re2)
+
+if(APPLE)
+  set_target_properties(re2 PROPERTIES
+    FRAMEWORK TRUE
+    FRAMEWORK_VERSION A
+    MACOSX_FRAMEWORK_IDENTIFIER com.google.re2
+    PUBLIC_HEADER "${RE2_HEADERS}"
+  )
+endif()
 
 if(UNIX)
   target_link_libraries(re2 PUBLIC Threads::Threads)
@@ -176,6 +201,7 @@ install(FILES ${RE2_HEADERS}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/re2)
 install(TARGETS re2
         EXPORT re2Targets
+        FRAMEWORK DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
This Pull Requst adds content into CMakeLists.txt so macOS, iOS, watchOS, and tvOS developers can build RE2 to [Apple Frameworks](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/WhatAreFrameworks.html).

### Build on macOS for macOS

```bash
cmake -B /tmp/re2-macos -S . -DCMAKE_INSTALL_PREFIX=/tmp/re2-macos/install
cmake --build /tmp/re2-macos
```

After the bulding, we will see the bundle directory in `/tmp/re2-macos/re2.framework`:

```
$ tree /tmp/re2-macos/re2.framework/
/tmp/re2-macos/re2.framework/
├── Headers -> Versions/Current/Headers
├── Resources -> Versions/Current/Resources
├── Versions
│   ├── A
│   │   ├── Headers
│   │   │   ├── bitmap256.h
│   │   │   ├── filtered_re2.h
│   │   │   ├── pod_array.h
│   │   │   ├── prefilter.h
│   │   │   ├── prefilter_tree.h
│   │   │   ├── prog.h
│   │   │   ├── re2.h
│   │   │   ├── regexp.h
│   │   │   ├── set.h
│   │   │   ├── sparse_array.h
│   │   │   ├── sparse_set.h
│   │   │   ├── stringpiece.h
│   │   │   ├── unicode_casefold.h
│   │   │   ├── unicode_groups.h
│   │   │   └── walker-inl.h
│   │   ├── Resources
│   │   │   └── Info.plist
│   │   └── re2
│   └── Current -> A
└── re2 -> Versions/Current/re2
```

### Build for iOS

Run the following commands on macOS with Xcode installed to build `re2.framework` for iOS Simulator. If you want to build for iOS devices, please change `-sdk iphonesimulator` into `-sdk iphoneos`.

```bash
 cmake -S . \
            -B  /tmp/re2-ios-sim \
            -DCMAKE_SYSTEM_NAME=iOS \
            -DCMAKE_OSX_SYSROOT="$(xcodebuild -version -sdk iphonesimulator Path)" \
            -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
            -DCMAKE_IOS_INSTALL_COMBINED=YES \
            -DCMAKE_INSTALL_PREFIX=/tmp/re2-ios-sim/install
 cmake --build /tmp/re2-ios-sim --target install
```

Check that all header files are copied into the framework.

```
$ tree /tmp/re2-ios-sim/re2.framework/
/tmp/re2-ios-sim/re2.framework/
├── Headers
│   ├── bitmap256.h
│   ├── filtered_re2.h
│   ├── pod_array.h
│   ├── prefilter.h
│   ├── prefilter_tree.h
│   ├── prog.h
│   ├── re2.h
│   ├── regexp.h
│   ├── set.h
│   ├── sparse_array.h
│   ├── sparse_set.h
│   ├── stringpiece.h
│   ├── unicode_casefold.h
│   ├── unicode_groups.h
│   └── walker-inl.h
├── Info.plist
└── re2
```