### PR TITLE
Disable warning for missing-field-initializers as well for clang.

### DIFF
--- a/re2/re2.h
+++ b/re2/re2.h
@@ -972,7 +972,7 @@ inline RE2::Arg RE2::Octal(T* ptr) {
 }
 
 // Silence warnings about missing initializers for members of LazyRE2.
-#if !defined(__clang__) && defined(__GNUC__)
+#if defined(__clang__) || defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 


### PR DESCRIPTION
The same warning shows up with clang++. Tested with clang-16 and clang-17.

Without that, my particular application with warnings turned on and -Werror fails.