### PR TITLE
[CMake] Added RE2_ENABLE_INSTALL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,14 @@ option(RE2_BUILD_FRAMEWORK "build RE2 as a framework" OFF)
 # so we provide an option similar to BUILD_TESTING, but just for RE2.
 option(RE2_BUILD_TESTING "enable testing for RE2" OFF)
 
+# When re2 is included as subproject (i.e. using add_subdirectory(re2))
+# in the source tree of a project that uses it, install rules are disabled.
+if(NOT CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+  option(RE2_ENABLE_INSTALL "enable install for RE2" OFF)
+else()
+  option(RE2_ENABLE_INSTALL "enable install for RE2" ON)
+endif()
+
 # The pkg-config Requires: field.
 set(REQUIRES)
 
@@ -237,32 +245,34 @@ if(RE2_BUILD_TESTING)
   endforeach()
 endif()
 
-install(TARGETS re2
-        EXPORT re2Targets
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        FRAMEWORK DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/re2
-        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(EXPORT re2Targets
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/re2
-        NAMESPACE re2::)
+if(RE2_ENABLE_INSTALL)
+  install(TARGETS re2
+          EXPORT re2Targets
+          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+          FRAMEWORK DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/re2
+          INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(EXPORT re2Targets
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/re2
+          NAMESPACE re2::)
 
-configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/re2Config.cmake.in
-                              ${CMAKE_CURRENT_BINARY_DIR}/re2Config.cmake
-                              INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/re2)
-write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/re2ConfigVersion.cmake
-                                 VERSION ${SONAME}.0.0
-                                 COMPATIBILITY SameMajorVersion)
+  configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/re2Config.cmake.in
+                                ${CMAKE_CURRENT_BINARY_DIR}/re2Config.cmake
+                                INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/re2)
+  write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/re2ConfigVersion.cmake
+                                  VERSION ${SONAME}.0.0
+                                  COMPATIBILITY SameMajorVersion)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/re2Config.cmake
-              ${CMAKE_CURRENT_BINARY_DIR}/re2ConfigVersion.cmake
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/re2)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/re2Config.cmake
+                ${CMAKE_CURRENT_BINARY_DIR}/re2ConfigVersion.cmake
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/re2)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/re2.pc.in
-               ${CMAKE_CURRENT_BINARY_DIR}/re2.pc
-               @ONLY)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/re2.pc.in
+                ${CMAKE_CURRENT_BINARY_DIR}/re2.pc
+                @ONLY)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/re2.pc
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/re2.pc
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+endif()


### PR DESCRIPTION
When using re2 as a submodule via CMake, we need to prevent the re2 from being installed. This is because the re2 installation target expects to find installed Abseil targets, which aren't available when being used as a submodule.

To address this, I've added a new CMake option `RE2_ENABLE_INSTALL`. This option controls whether re2 is installable and is set by default if it's used in a standard way. Hence, no change for the existing use-case is introduced. The only difference is when re2 is included as a submodule. In this specific case, re2 won't be installed by default. This will solve the missing Abseil dependency issue.