### PR TITLE
Fixed location of `cc_configure_extension`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ core
 obj/
 benchlog.*
 user.bazelrc
+
+bazel-*
+MODULE.bazel.lock

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,7 +19,7 @@ bazel_dep(name = "pybind11_bazel", version = "2.12.0")
 
 # This is a temporary hack for `x64_x86_windows`.
 # TODO(junyer): Remove whenever no longer needed.
-cc_configure = use_extension("@bazel_tools//tools/cpp:cc_configure.bzl", "cc_configure_extension")
+cc_configure = use_extension("@rules_cc//cc:extensions.bzl", "cc_configure_extension")
 use_repo(cc_configure, "local_config_cc")
 
 # These dependencies will be ignored when the `re2` module is not


### PR DESCRIPTION
`cc_configure_extension` no longer comes from `bazel_tools`.

See https://github.com/bazelbuild/bazel/issues/24426.