### PR TITLE
Fix null pointer dereference in FilteredRE2::RegisterDynamic

### DIFF
--- a/re2/filtered_re2.cc
+++ b/re2/filtered_re2.cc
@@ -60,6 +60,9 @@ RE2::ErrorCode FilteredRE2::Add(absl::string_view pattern,
     }
     delete re;
   } else {
+    if (id == nullptr) {
+      return false;  // maybe other return values in the future
+    }
     *id = static_cast<int>(re2_vec_.size());
     re2_vec_.push_back(re);
   }


### PR DESCRIPTION
In `re2/filtered_re2.cc`, the function `RegisterDynamic` writes to the output parameter `id` without first checking whether it is `nullptr`. If a caller passes `nullptr`, this leads to undefined behavior and can crash the program.

This change adds a null check for `id`. If `id` is null, the function returns `false` early to avoid dereferencing it.

This fixes a potential crash when using `FilteredRE2` with invalid arguments.