### PR TITLE
First pass at BCR release automation

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,34 @@
+{
+  "homepage": "https://github.com/google/re2",
+  "maintainers": [
+      {
+          "email": "rsc@google.com",
+          "github": "rsc",
+          "github_user_id": 104030,
+          "name": "Russ Cox"
+      }
+  ],
+  "repository": [
+      "github:google/re2"
+  ],
+  "versions": [
+      "2021-09-01",
+      "2023-06-02",
+      "2023-08-01",
+      "2023-09-01",
+      "2023-11-01",
+      "2024-02-01",
+      "2024-03-01",
+      "2024-04-01",
+      "2024-05-01",
+      "2024-06-01",
+      "2024-07-01",
+      "2024-07-02",
+      "2024-07-02.bcr.1",
+      "2025-06-26"
+  ],
+  "yanked_versions": {
+      "2023-06-02": "bad compatibility_level, upgrade to 2023-09-01 or newer",
+      "2023-08-01": "bad compatibility_level, upgrade to 2023-09-01 or newer"
+  }
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,48 @@
+matrix:
+  platform:
+  - rockylinux8
+  - debian10
+  - ubuntu2004
+  - macos
+  - windows
+  bazel:
+  - 7.x
+  - 8.0.0rc6
+tasks:
+  build:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++14'
+    build_targets:
+    - '@re2//:re2'
+    - '@re2//python:re2'
+
+bcr_test_module:
+  module_path: '.'
+
+  matrix:
+    platform:
+    - rockylinux8
+    - debian10
+    - ubuntu2004
+    - macos
+    - windows
+    bazel:
+    - 7.x
+    - 8.0.0rc6
+  tasks:
+    test:
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_flags:
+      - '--cxxopt=-std=c++14'
+      test_targets:
+      - '//:all'
+      - '-//:dfa_test'
+      - '-//:exhaustive1_test'
+      - '-//:exhaustive2_test'
+      - '-//:exhaustive3_test'
+      - '-//:exhaustive_test'
+      - '-//:random_test'
+      - '//python:all'

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.zip"
+}

--- a/.github/workflows/publish_to_bcr.yml
+++ b/.github/workflows/publish_to_bcr.yml
@@ -1,0 +1,29 @@
+on:
+  # Automated trigger from the release.yaml workflow
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+  # Allow manual triggering from GH UI
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+jobs:
+  publish:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.2.2
+    with:
+      tag_name: ${{ inputs.tag_name }}
+      # This workflow seems to require keeping a fork of the upstream to open
+      # PRs from.
+      registry_fork: j2kun/bazel-central-registry
+      attest: true
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    secrets:
+      # Necessary to push to the BCR fork, and to open a pull request against a registry
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,10 @@ jobs:
             *.tar.gz *.zip *.sigstore* \
             --repo "${GITHUB_REPOSITORY}"
         shell: bash
+  publish_to_bcr:
+    needs: create
+    uses: ./.github/workflows/publish_to_bcr.yaml
+    with:
+      tag_name: ${{ github.ref_name }}
+    secrets:
+      BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,7 +19,7 @@ bazel_dep(name = "pybind11_bazel", version = "2.13.6")
 
 # This is a temporary hack for `x64_x86_windows`.
 # TODO(junyer): Remove whenever no longer needed.
-cc_configure = use_extension("@rules_cc//cc:extensions.bzl", "cc_configure_extension")
+cc_configure = use_extension("@rules_cc//cc:extensions.bzl", "cc_configure_extension", dev_dependency = True)
 use_repo(cc_configure, "local_config_cc")
 
 # These dependencies will be ignored when the `re2` module is not


### PR DESCRIPTION
Cf. https://github.com/google/re2/issues/556

According to step 3 of https://github.com/google/re2/issues/556#issuecomment-3138253693, this needs a "Classic" PAT with "workflow" and "repo" permissions (fine-grained PATs are not supported). The PAT needs to be saved as `BCR_PUBLISH_TOKEN` in the repository settings.

This action appears to create a PR from a fork of the BCR GitHub repo, so someone needs to maintain that fork. I put `j2kun/bazel-central-registry` since I occasionally update BCR with new versions of things. But I bet this action will have problems using a PAT from a `google`-owned repo to push commits to my personal repo. So maybe we would need a `google/bazel-central-registry` fork as well (which someone would likely need to occasionally sync). It doesn't look like Google has one yet :)

I don't know anything about attestation, so I'm not sure if that part of the workflow will also have issues.

The last commit adds the call to `publish_to_bcr.yml` from `release.yml`, but we may want to omit that and manually trigger the BCR workflow until getting the kinks worked out.