### PR TITLE
Add C++20 modules support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.orig
 core
 obj/
+build/
 benchlog.*
 user.bazelrc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ option(RE2_TEST "build and run RE2 tests" OFF)
 option(RE2_BENCHMARK "build RE2 benchmarks" OFF)
 option(RE2_BUILD_TESTING "build and run RE2 tests; build RE2 benchmarks" OFF)
 
+# RE2 Modules option
+option(RE2_MODULES "build RE2 modules" OFF)
+
 # The pkg-config Requires: field.
 set(REQUIRES)
 
@@ -146,6 +149,18 @@ target_include_directories(re2 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_D
 set_target_properties(re2 PROPERTIES PUBLIC_HEADER "${RE2_HEADERS}")
 set_target_properties(re2 PROPERTIES SOVERSION ${SONAME} VERSION ${SONAME}.0.0)
 add_library(re2::re2 ALIAS re2)
+
+if (RE2_MODULES)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+        message(STATUS "Building re2 C++ modules")
+    else()
+        message(WARNING "Skipping re2 C++ modules (requires CMake 3.28+, found ${CMAKE_VERSION})")
+    endif()
+endif()
+
+if(RE2_MODULES AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+	add_subdirectory(re2/modules)
+endif()
 
 if(APPLE AND RE2_BUILD_FRAMEWORK)
   set_target_properties(re2 PROPERTIES

--- a/re2/modules/CMakeLists.txt
+++ b/re2/modules/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.28)
+
+add_library(re2modules)
+add_library(re2::modules ALIAS re2modules)
+
+set(RE2_MODULES
+	re2.cppm
+)
+
+target_link_libraries(re2modules PUBLIC re2::re2)
+
+if(NOT COMMAND configure_cpp_module_target)
+    function(configure_cpp_module_target target)
+        target_sources(${target} PUBLIC FILE_SET CXX_MODULES FILES ${RE2_MODULES})
+    endfunction()
+endif()
+
+configure_cpp_module_target(re2modules)
+
+set_target_properties(re2modules
+    PROPERTIES
+    VERSION ${SHARED_LIBRARY_VERSION} 
+    SOVERSION ${SHARED_LIBRARY_VERSION}
+    OUTPUT_NAME re2modules
+    DEFINE_SYMBOL re2modules_EXPORTS
+)
+
+target_include_directories(re2modules
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    PRIVATE 
+        ${CMAKE_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+target_compile_features(re2modules PUBLIC cxx_std_20)

--- a/re2/modules/re2.cppm
+++ b/re2/modules/re2.cppm
@@ -1,0 +1,21 @@
+// Copyright 2025 The RE2 Authors.  All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+module;
+
+#include "re2/filtered_re2.h"
+#include "re2/re2.h"
+#include "re2/set.h"
+#include "re2/stringpiece.h"
+
+export module re2;
+
+export namespace re2 {
+    using re2::Prog;
+    using re2::Regexp;
+    using re2::RE2;
+    using re2::PrefilterTree;
+    using re2::FilteredRE2;
+    using re2::StringPiece;
+}


### PR DESCRIPTION
This pull request adds support for C++20 modules, and is supported using CMake. (Other build systems can be supported in the future.) We can now import the library with:
```
import re2;

using re2::RE2;

// ...
String pattern = "h.*o";
String input = "hello";
bool match = RE2::FullMatch(input, pattern);
```