### PR TITLE
re2: remove unnecessary & in MutexLock usage

### DIFF
--- a/re2/dfa.cc
+++ b/re2/dfa.cc
@@ -1015,7 +1015,7 @@ void DFA::RunWorkqOnByte(Workq* oldq, Workq* newq,
 DFA::State* DFA::RunStateOnByteUnlocked(State* state, int c) {
   // Keep only one RunStateOnByte going
   // even if the DFA is being run by multiple threads.
-  absl::MutexLock l(&mutex_);
+  absl::MutexLock l(mutex_);
   return RunStateOnByte(state, c);
 }
 
@@ -1267,7 +1267,7 @@ DFA::StateSaver::~StateSaver() {
 DFA::State* DFA::StateSaver::Restore() {
   if (is_special_)
     return special_;
-  absl::MutexLock l(&dfa_->mutex_);
+  absl::MutexLock l(dfa_->mutex_);
   State* s = dfa_->CachedState(inst_, ninst_, flag_);
   if (s == NULL)
     ABSL_LOG(DFATAL) << "StateSaver failed to restore state.";
@@ -1730,7 +1730,7 @@ bool DFA::AnalyzeSearchHelper(SearchParams* params, StartInfo* info,
   if (start != NULL)
     return true;
 
-  absl::MutexLock l(&mutex_);
+  absl::MutexLock l(mutex_);
   start = info->start.load(std::memory_order_relaxed);
   if (start != NULL)
     return true;
@@ -2050,7 +2050,7 @@ bool DFA::PossibleMatchRange(std::string* min, std::string* max, int maxlen) {
   // Build minimum prefix.
   State* s = params.start;
   min->clear();
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   for (int i = 0; i < maxlen; i++) {
     if (previously_visited_states[s] > kMaxEltRepetitions)
       break;

--- a/re2/testing/regexp_benchmark.cc
+++ b/re2/testing/regexp_benchmark.cc
@@ -964,7 +964,7 @@ void SearchRE2(benchmark::State& state, const char* regexp,
 
 Prog* GetCachedProg(const char* regexp) {
   static auto& mutex = *new absl::Mutex;
-  absl::MutexLock lock(&mutex);
+  absl::MutexLock lock(mutex);
   static auto& cache = *new absl::flat_hash_map<std::string, Prog*>;
   Prog* prog = cache[regexp];
   if (prog == NULL) {
@@ -982,7 +982,7 @@ Prog* GetCachedProg(const char* regexp) {
 
 PCRE* GetCachedPCRE(const char* regexp) {
   static auto& mutex = *new absl::Mutex;
-  absl::MutexLock lock(&mutex);
+  absl::MutexLock lock(mutex);
   static auto& cache = *new absl::flat_hash_map<std::string, PCRE*>;
   PCRE* re = cache[regexp];
   if (re == NULL) {
@@ -995,7 +995,7 @@ PCRE* GetCachedPCRE(const char* regexp) {
 
 RE2* GetCachedRE2(const char* regexp) {
   static auto& mutex = *new absl::Mutex;
-  absl::MutexLock lock(&mutex);
+  absl::MutexLock lock(mutex);
   static auto& cache = *new absl::flat_hash_map<std::string, RE2*>;
   RE2* re = cache[regexp];
   if (re == NULL) {


### PR DESCRIPTION
Update for Abseil churn from mid-2025, now that vcpkg has updated.