### PR TITLE
Add C++20 modules support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.orig
 core
 obj/
+build/
 benchlog.*
 user.bazelrc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(RE2_BUILD_FRAMEWORK "build RE2 as a framework" OFF)
 option(RE2_TEST "build and run RE2 tests" OFF)
 option(RE2_BENCHMARK "build RE2 benchmarks" OFF)
 option(RE2_BUILD_TESTING "build and run RE2 tests; build RE2 benchmarks" OFF)
+option(RE2_BUILD_MODULES "build RE2 modules" OFF)
 
 # RE2_INSTALL (which defaults to ON) controls whether the installation
 # rules are generated.
@@ -150,6 +151,15 @@ target_include_directories(re2 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_D
 set_target_properties(re2 PROPERTIES PUBLIC_HEADER "${RE2_HEADERS}")
 set_target_properties(re2 PROPERTIES SOVERSION ${SONAME} VERSION ${SONAME}.0.0)
 add_library(re2::re2 ALIAS re2)
+
+if(RE2_BUILD_MODULES)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+        message(STATUS "Building re2 C++ modules")
+        add_subdirectory(re2/modules)
+    else()
+        message(WARNING "Skipping re2 C++ modules (requires CMake 3.28+, found ${CMAKE_VERSION})")
+    endif()
+endif()
 
 if(APPLE AND RE2_BUILD_FRAMEWORK)
   set_target_properties(re2 PROPERTIES

--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ If you are using RE2 from another project, you need to make sure you are
 using at least C++17.
 See the RE2 [.bazelrc](https://github.com/google/re2/blob/main/.bazelrc) file for an example.
 
+If you wish to use C++ modules, use `-DRE2_BUILD_MODULES=ON`. This requires at least C++20.
+
 ### Ports and Wrappers
 
 RE2 is implemented in C++.

--- a/re2/modules/CMakeLists.txt
+++ b/re2/modules/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.28)
+
+add_library(re2modules)
+add_library(re2::modules ALIAS re2modules)
+
+set(RE2_MODULES
+	re2.cppm
+)
+
+target_link_libraries(re2modules PUBLIC re2::re2)
+
+if(NOT COMMAND configure_cpp_module_target)
+    function(configure_cpp_module_target target)
+        target_sources(${target} PUBLIC FILE_SET CXX_MODULES FILES ${RE2_MODULES})
+    endfunction()
+endif()
+
+configure_cpp_module_target(re2modules)
+
+set_target_properties(re2modules
+    PROPERTIES
+    VERSION ${SHARED_LIBRARY_VERSION} 
+    SOVERSION ${SHARED_LIBRARY_VERSION}
+    OUTPUT_NAME re2modules
+    DEFINE_SYMBOL re2modules_EXPORTS
+)
+
+target_include_directories(re2modules
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    PRIVATE 
+        ${CMAKE_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+target_compile_features(re2modules PUBLIC cxx_std_20)

--- a/re2/modules/re2.cppm
+++ b/re2/modules/re2.cppm
@@ -1,0 +1,33 @@
+// Copyright 2026 The RE2 Authors.  All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+module;
+
+#include "re2/filtered_re2.h"
+#include "re2/re2.h"
+#include "re2/set.h"
+#include "re2/stringpiece.h"
+
+export module re2;
+
+export namespace re2 {
+    using re2::Prog;
+    using re2::Regexp;
+    using re2::RE2;
+    using re2::PrefilterTree;
+    using re2::FilteredRE2;
+    using re2::StringPiece;
+
+    namespace hooks {
+        using re2::hooks::context;
+        using re2::hooks::DFASearchFailure;
+        using re2::hooks::DFAStateCacheReset;
+        using re2::hooks::DFASearchFailureCallback;
+        using re2::hooks::DFAStateCacheResetCallback;
+        using re2::hooks::GetDFASearchFailureHook;
+        using re2::hooks::GetDFAStateCacheResetHook;
+        using re2::hooks::SetDFASearchFailureHook;
+        using re2::hooks::SetDFAStateCacheResetHook;
+    }
+}


### PR DESCRIPTION
This PR adds C++20 modules support. No existing issue covers this pull request. The module generated is `re2` and enabled using the CMake option `RE2_BUILD_MODULES`.

Example:

```cpp
import re2;

using re2::RE2;

// ...
String pattern = "h.*o";
String input = "hello";
bool match = RE2::FullMatch(input, pattern);
```

Build using:
```sh
cmake -S . -B build -G Ninja -DRE2_MODULES=ON
cmake --build build
```