### PR TITLE
ci: pin all actions to full commit SHAs and add workflow permissions

### DIFF
--- a/.github/workflows/ci-bazel.yml
+++ b/.github/workflows/ci-bazel.yml
@@ -16,11 +16,11 @@ jobs:
         # Keep in sync with python.yml.
         ver: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: bazel-contrib/setup-bazel@0.15.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: bazel-contrib/setup-bazel@8d2cb86a3680a820c3e219597279ce3f80d17a47 # 0.15.0
         with:
           bazelisk-version: '1.x'
-      - uses: actions/setup-python@v5.6.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.ver }}
       - name: Prepare Python ${{ matrix.ver }} environment

--- a/.github/workflows/ci-cmake.yml
+++ b/.github/workflows/ci-cmake.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         build_shared_libs: [OFF, ON]
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Abseil, GoogleTest and Benchmark
         run: |
           vcpkg update
@@ -31,7 +31,7 @@ jobs:
       matrix:
         build_shared_libs: [OFF, ON]
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Abseil, GoogleTest and Benchmark
         run: |
           brew update
@@ -46,7 +46,7 @@ jobs:
       matrix:
         build_shared_libs: [OFF, ON]
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Abseil, GoogleTest and Benchmark
         run: |
           vcpkg update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       # (The other two flags are the default provided for CXXFLAGS in Makefile.)
       CXXFLAGS: -O3 -g -std=c++${{ matrix.ver }}
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Abseil, GoogleTest and Benchmark
         run: |
           brew update
@@ -42,7 +42,7 @@ jobs:
       CXX: clang++-${{ matrix.ver }}
       PKG_CONFIG_PATH: /usr/local/share/vcpkg/installed/x64-linux/lib/pkgconfig
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Clang ${{ matrix.ver }}
         run: |
           # Avoid `Conflicts: python3-lldb-x.y` between packages.
@@ -69,7 +69,7 @@ jobs:
       CXX: g++-${{ matrix.ver }}
       PKG_CONFIG_PATH: /usr/local/share/vcpkg/installed/x64-linux/lib/pkgconfig
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Install Abseil, GoogleTest and Benchmark
         run: |
           vcpkg update

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,13 +17,13 @@ jobs:
       # Bazel fails if the username is unknown.
       USER: runner
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: bazel-contrib/setup-bazel@0.15.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: bazel-contrib/setup-bazel@8d2cb86a3680a820c3e219597279ce3f80d17a47 # 0.15.0
         with:
           bazelisk-version: '1.x'
       - run: app/build.sh
         shell: bash
-      - uses: actions/upload-pages-artifact@v3.0.1
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: app/deploy
   deploy:
@@ -37,5 +37,5 @@ jobs:
     environment: github-pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: actions/deploy-pages@v4.0.5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -37,11 +37,11 @@ jobs:
       # Bazel fails if the username is unknown.
       USER: runner
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       # Stash the timestamp for the commit SHA that triggered the workflow.
       - run: echo "timestamp=$(git log -1 --pretty=%ct)" >> "${GITHUB_ENV}"
         shell: bash
-      - uses: bazel-contrib/setup-bazel@0.15.0
+      - uses: bazel-contrib/setup-bazel@8d2cb86a3680a820c3e219597279ce3f80d17a47 # 0.15.0
         with:
           bazelisk-version: '1.x'
       - name: Prepare Python ${{ matrix.ver }} environment
@@ -69,7 +69,7 @@ jobs:
           "${PYTHON}" re2_test.py
         shell: bash
         working-directory: python
-      - uses: actions/upload-artifact@v4.6.2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ hashFiles('python/google_re2-*.whl') }}
           path: python/google_re2-*.whl
@@ -98,14 +98,14 @@ jobs:
       # Otherwise, Python refuses to install the built wheel!
       SYSTEM_VERSION_COMPAT: 0
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       # Stash the timestamp for the commit SHA that triggered the workflow.
       - run: echo "timestamp=$(git log -1 --pretty=%ct)" >> "${GITHUB_ENV}"
         shell: bash
-      - uses: bazel-contrib/setup-bazel@0.15.0
+      - uses: bazel-contrib/setup-bazel@8d2cb86a3680a820c3e219597279ce3f80d17a47 # 0.15.0
         with:
           bazelisk-version: '1.x'
-      - uses: actions/setup-python@v5.6.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.ver }}
       - name: Prepare Python ${{ matrix.ver }} environment
@@ -134,7 +134,7 @@ jobs:
           python re2_test.py
         shell: bash
         working-directory: python
-      - uses: actions/upload-artifact@v4.6.2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ hashFiles('python/google_re2-*.whl') }}
           path: python/google_re2-*.whl
@@ -160,11 +160,11 @@ jobs:
       BAZEL_CPU: ${{ matrix.arch.bazel-name }}_windows
       PLAT_NAME: ${{ matrix.arch.python-name }}
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       # Stash the timestamp for the commit SHA that triggered the workflow.
       - run: echo "timestamp=$(git log -1 --pretty=%ct)" >> "${GITHUB_ENV}"
         shell: bash
-      - uses: bazel-contrib/setup-bazel@0.15.0
+      - uses: bazel-contrib/setup-bazel@8d2cb86a3680a820c3e219597279ce3f80d17a47 # 0.15.0
         with:
           bazelisk-version: '1.x'
       # Lowercase the architecture name for `actions/setup-python`.
@@ -172,7 +172,7 @@ jobs:
           ARCHITECTURE=${{ matrix.arch.name }}
           echo "architecture=${ARCHITECTURE,,}" >> "${GITHUB_ENV}"
         shell: bash
-      - uses: actions/setup-python@v5.6.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.ver }}
           architecture: ${{ env.architecture }}
@@ -201,7 +201,7 @@ jobs:
           python re2_test.py
         shell: bash
         working-directory: python
-      - uses: actions/upload-artifact@v4.6.2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ hashFiles('python/google_re2-*.whl') }}
           path: python/google_re2-*.whl
@@ -217,11 +217,11 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       # Stash the timestamp for the commit SHA that triggered the workflow.
       - run: echo "timestamp=$(git log -1 --pretty=%ct)" >> "${GITHUB_ENV}"
         shell: bash
-      - uses: actions/setup-python@v5.6.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.x'
       - name: Prepare Python 3.x environment
@@ -237,7 +237,7 @@ jobs:
           python -m build --sdist
         shell: bash
         working-directory: python
-      - uses: actions/download-artifact@v4.3.0
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: python
       - name: Set build number to ${{ inputs.build }}
@@ -253,6 +253,6 @@ jobs:
         shell: bash
         working-directory: python
       - if: inputs.build >= 1
-        uses: pypa/gh-action-pypi-publish@v1.13.0
+        uses: pypa/gh-action-pypi-publish@106e0b0b7c337fa67ed433972f777c6357f78598 # v1.13.0
         with:
           packages-dir: python/dist

--- a/.github/workflows/release-bazel.yml
+++ b/.github/workflows/release-bazel.yml
@@ -16,9 +16,12 @@ on:
       BCR_PUBLISH_TOKEN:
         description: 'Token for pushing to re2-machine/bazel-central-registry'
         required: true
+permissions:
+  contents: read
+
 jobs:
   release:
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.2.2
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@096e4724c760aa0024916fe772701c06926f4c49 # v0.2.2
     with:
       draft: false
       tag_name: ${{ inputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: |
           gh release create "${GITHUB_REF_NAME}" \
             --generate-notes --latest --verify-tag \
@@ -28,7 +28,7 @@ jobs:
             --archive zip \
             --repo "${GITHUB_REPOSITORY}"
         shell: bash
-      - uses: sigstore/gh-action-sigstore-python@v3.0.1
+      - uses: sigstore/gh-action-sigstore-python@f7ad0af51a5648d09a20d00370f0a91c3bdf8f84 # v3.0.1
         with:
           # N.B. This is a whitespace-separated string!
           inputs: '*.tar.gz *.zip'


### PR DESCRIPTION
## Summary

All 7 CI workflow files used mutable action tag references. This PR pins every `uses:` to its full commit SHA across the entire `.github/workflows/` directory, and adds a missing `permissions` block to `release-bazel.yml`.

### Changes

**Pin all `uses:` to full commit SHAs** (original tags kept as comments)

| Action | Was | Now |
|--------|-----|-----|
| `actions/checkout` | `@v4.2.2` / `@v4.1.7` | `@11bd71901b` / `@692973e3d9` |
| `actions/setup-python` | `@v5.6.0` | `@a26af69be9` |
| `actions/upload-pages-artifact` | `@v3.0.1` | `@56afc609e7` |
| `actions/upload-artifact` | `@v4.6.2` | `@ea165f8d65` |
| `actions/download-artifact` | `@v4.3.0` | `@d3f86a106a` |
| `actions/deploy-pages` | `@v4.0.5` | `@d6db90164a` |
| `bazel-contrib/setup-bazel` | `@0.15.0` | `@8d2cb86a36` |
| `bazel-contrib/publish-to-bcr` | `@v0.2.2` | `@096e4724c7` |
| `sigstore/gh-action-sigstore-python` | `@v3.0.1` | `@f7ad0af51a` |
| `pypa/gh-action-pypi-publish` | `@v1.13.0` | `@106e0b0b7c` |

**Add `permissions: contents: read` to `release-bazel.yml`**

This was the only workflow missing a top-level permissions block. The job-level `permissions` for the release job are already correctly scoped (`contents: write`, `id-token: write`, `attestations: write`) and are unchanged — the workflow-level `contents: read` sets a safe default for any future jobs added to the file.

Qualifies under the [Google Open Source Patch Rewards Program](https://bughunters.google.com/open-source-security/patch-rewards) for proactive CI/supply-chain security hardening.