### PR TITLE
python: reject non-contiguous buffers

### DIFF
--- a/python/_re2.cc
+++ b/python/_re2.cc
@@ -38,6 +38,11 @@ namespace py = pybind11;
 // the py::buffer_info manages a reference count to the py::buffer, so it
 // must be constructed and subsequently destructed while holding the GIL.
 static inline absl::string_view FromBytes(const py::buffer_info& bytes) {
+  if (bytes.ndim != 1 || bytes.itemsize != 1 || bytes.strides.size() != 1 ||
+      bytes.strides[0] != 1) {
+    throw py::type_error(
+        "buffer must be a one-dimensional contiguous buffer of bytes");
+  }
   char* data = reinterpret_cast<char*>(bytes.ptr);
   ssize_t size = bytes.size;
   return absl::string_view(data, size);

--- a/python/re2_test.py
+++ b/python/re2_test.py
@@ -301,6 +301,19 @@ class Re2RegexpTest(ReRegexpTest):
     # ... whereas this is fine, of course.
     re2.compile(b'.?', options=options)
 
+  def test_noncontiguous_buffer_rejected(self):
+    regexp = re2.compile(b'.')
+    for text in (memoryview(b'0123456789')[::-1],
+                 memoryview(b'0123456789')[::2]):
+      with self.assertRaisesRegex(
+          re2.error, 'one-dimensional contiguous buffer of bytes'):
+        regexp.search(text)
+
+    for pattern in (memoryview(b'.')[::-1], memoryview(b'..')[::2]):
+      with self.assertRaisesRegex(
+          re2.error, 'one-dimensional contiguous buffer of bytes'):
+        re2.compile(pattern)
+
   @parameterized.parameters(
       (u'\\p{Lo}', u'\u0ca0_\u0ca0', [(0, 1), (2, 3)]),
       (b'\\p{Lo}', b'\xe0\xb2\xa0_\xe0\xb2\xa0', [(0, 3), (4, 7)]),


### PR DESCRIPTION
The Python binding requests a full buffer view but previously treated every buffer as a contiguous one-dimensional byte string. This is unsafe for non-contiguous, multi-dimensional, or wider-item buffers: the pointer arithmetic and byte length do not describe the logical view.

This change validates the buffer layout before constructing an absl::string_view. Unsupported layouts are rejected unless the buffer is one-dimensional, byte-sized, and has a unit stride.

A regression test covers reversed and strided memoryviews for both pattern and input paths.

Validation:
- RE2 C++ CMake suite: 20/20 tests passed.
- - Python binding suite: 244 tests passed.
- - Independent comparison: the parent revision accepted strided, reversed, two-dimensional, and wide-item buffers; this revision rejects all four.
- - No upstream source files outside the Python binding and its tests are changed.